### PR TITLE
fix: Set indexing offset based on page size

### DIFF
--- a/src/indexer/src/lib/document-processor.ts
+++ b/src/indexer/src/lib/document-processor.ts
@@ -179,6 +179,8 @@ function filenameToId(filename: string) {
 async function extractTextFromPdf(data: Buffer): Promise<ContentPage[]> {
   const pages: ContentPage[] = [];
   const pdf = await pdfjs.getDocument(new Uint8Array(data)).promise;
+  let offset = 0;
+
   for (let i = 1; i <= pdf.numPages; i++) {
     const page = await pdf.getPage(i);
     const textContent = await page.getTextContent();
@@ -196,7 +198,10 @@ async function extractTextFromPdf(data: Buffer): Promise<ContentPage[]> {
         return string_;
       })
       .join('');
-    pages.push({ content: text + '\n', offset: 0, page: i });
+
+    pages.push({ content: text + '\n', offset, page: i });
+    offset += text.length;
+
   }
   return pages;
 }

--- a/src/indexer/test.http
+++ b/src/indexer/test.http
@@ -51,7 +51,7 @@ Content-Type: multipart/form-data; boundary=Boundary
 Content-Disposition: form-data; name="file"; filename="test.pdf"
 Content-Type: application/pdf
 
-< ../../data/PerksPlus.pdf
+< ../../data/support.pdf
 --Boundary
 Content-Disposition: form-data; name="options"
 


### PR DESCRIPTION
Set the offset of each extracted PDF page based on the number of characters read since the start of the PDF file.

noissue